### PR TITLE
Allow setting active_low with 'True' and 'False' too

### DIFF
--- a/sysfs/gpio.py
+++ b/sysfs/gpio.py
@@ -91,14 +91,14 @@ class Pin(object):
         @type  edge: int
         @param edge: The edge transition that triggers callback,
                      enumerated by C{Edge}
-        @type active_low: int
+        @type active_low: int|bool
         @param active_low: Indicator of whether this pin uses inverted
                            logic for HIGH-LOW transitions.
         """
         self._number = number
         self._direction = direction
         self._callback  = callback
-        self._active_low = active_low
+        self._active_low = int(active_low)
 
         self._fd = open(self._sysfs_gpio_value_path(), 'r+')
 


### PR DESCRIPTION
Hi,

i want to propose this change to the pin allocation method which allows to set the active_low setting with boolean {True,False}. I think it feels more intuitive to use

`active_low=True` instead of `active_low=1`.

This change allows both methods.
Cheers!